### PR TITLE
Update HttpUtility.cs

### DIFF
--- a/IoTHubAmqp/IoTHubAmqp/HttpUtility.cs
+++ b/IoTHubAmqp/IoTHubAmqp/HttpUtility.cs
@@ -6,7 +6,7 @@ namespace IoTHubAmqp
     using System;
     using System.Text;
 
-    class HttpUtility
+    public static class HttpUtility
     {
         public static string UrlEncode(string str)
         {


### PR DESCRIPTION
The samples on here won't work with the Nuget package that has been publish because HttpUtility was not marked as public (defaults to internal).  Also, there are only static methods in this class, so changing class to be static as well.
